### PR TITLE
un-"fix" the Qine link so that I can delete the bad tag

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -58,7 +58,7 @@
             "description" : "",
             "license" : null,
             "page" : [{ "name" : "GitHub", "url" : "https://github.com/sgrunt/qine" }],
-            "archive_link" : "https://github.com/sgrunt/qine/archive/v0.0.5.zip",
+            "archive_link" : "https://github.com/sgrunt/qine/archive/0.0.5.zip",
             "hash" : { "sha256" : "8d7a9a57fca9aae0bb2989c0c2124185221b7bb136e9e3fa00fbda64213ff871" },
             "version" : "0.0.5"
         }


### PR DESCRIPTION
The original link is working now.

This reverts commit fce8e432d9c2acaad3c3122421136fba49b34b16.