### PR TITLE
Bump French mod to 0.7.0

### DIFF
--- a/input-locations.json
+++ b/input-locations.json
@@ -77,8 +77,8 @@
 	},
 	{
 		"type": "modZip",
-		"urlZip": "https://github.com/L-Sherry/French-CC/archive/v0.6.0.zip",
-		"source": "French-CC-0.6.0"
+		"urlZip": "https://github.com/L-Sherry/French-CC/archive/v0.7.0.zip",
+		"source": "French-CC-0.7.0"
 	},
 	{
 		"type": "modZip",

--- a/mods.json
+++ b/mods.json
@@ -219,11 +219,11 @@
                     "url": "https://github.com/L-Sherry/French-CC"
                 }
             ],
-            "archive_link": "https://github.com/L-Sherry/French-CC/archive/v0.6.0.zip",
+            "archive_link": "https://github.com/L-Sherry/French-CC/archive/v0.7.0.zip",
             "hash": {
-                "sha256": "767e2edd91c41e292e6c9cf2632cb64a8109b423155386f3c031bef14ba78d1e"
+                "sha256": "6ee8419a23b0b8a66f945abd66e800127c6dadbc1160ad1c4a99c360dcf36563"
             },
-            "version": "0.6.0"
+            "version": "0.7.0"
         },
         "Kit Player": {
             "name": "Kit Player",

--- a/npDatabase.json
+++ b/npDatabase.json
@@ -327,7 +327,7 @@
             "description": "CrossCode en français !",
             "homepage": "https://github.com/L-Sherry/French-CC",
             "postload": "mod.js",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "ccmodDependencies": {
                 "Localize Me": ">=0.4 <1"
             }
@@ -335,10 +335,10 @@
         "installation": [
             {
                 "type": "modZip",
-                "url": "https://github.com/L-Sherry/French-CC/archive/v0.6.0.zip",
-                "source": "French-CC-0.6.0",
+                "url": "https://github.com/L-Sherry/French-CC/archive/v0.7.0.zip",
+                "source": "French-CC-0.7.0",
                 "hash": {
-                    "sha256": "767e2edd91c41e292e6c9cf2632cb64a8109b423155386f3c031bef14ba78d1e"
+                    "sha256": "6ee8419a23b0b8a66f945abd66e800127c6dadbc1160ad1c4a99c360dcf36563"
                 }
             }
         ]


### PR DESCRIPTION
This fixes a crash. Oh, and everything is translated now.

The sha256 of the zip should be
`6ee8419a23b0b8a66f945abd66e800127c6dadbc1160ad1c4a99c360dcf36563`

Full changelog at https://github.com/L-Sherry/French-CC/releases/