### PR TITLE
Bump Localize-Me version to 0.5.1

### DIFF
--- a/input-locations.json
+++ b/input-locations.json
@@ -86,8 +86,8 @@
 	},
 	{
 		"type": "modZip",
-		"urlZip": "https://github.com/L-Sherry/Localize-me/archive/v0.4.3.zip",
-		"source": "Localize-me-0.4.3"
+		"urlZip": "https://github.com/L-Sherry/Localize-me/archive/v0.5.1.zip",
+		"source": "Localize-me-0.5.1"
 	},
 	{
 		"type": "modZip",

--- a/input-locations.json
+++ b/input-locations.json
@@ -86,7 +86,7 @@
 	},
 	{
 		"type": "modZip",
-		"urlZip": "https://github.com/L-Sherry/Localize-me/archive/v0.5.1.zip",
+		"urlZip": "https://github.com/L-Sherry/Localize-me/archive/0.5.1.zip",
 		"source": "Localize-me-0.5.1"
 	},
 	{

--- a/mods.json
+++ b/mods.json
@@ -254,11 +254,11 @@
                     "url": "https://github.com/L-Sherry/Localize-me"
                 }
             ],
-            "archive_link": "https://github.com/L-Sherry/Localize-me/archive/v0.4.3.zip",
+            "archive_link": "https://github.com/L-Sherry/Localize-me/archive/0.5.1.zip",
             "hash": {
-                "sha256": "fb08dd95de63af3b057000161f74c6770012f94cc4d5718b8c73aba9055cfc0a"
+                "sha256": "02f058f2574c233e98e5f450b20683a5133dceef59fba8decf6e04b736f89f02"
             },
-            "version": "0.4.3"
+            "version": "0.5.1"
         },
         "French": {
             "name": "French",

--- a/npDatabase.json
+++ b/npDatabase.json
@@ -369,15 +369,15 @@
             "homepage": "https://github.com/L-Sherry/Localize-me",
             "description": "Add support for more locales, languages and translations",
             "postload": "mod.js",
-            "version": "0.4.3"
+            "version": "0.5.1"
         },
         "installation": [
             {
                 "type": "modZip",
-                "url": "https://github.com/L-Sherry/Localize-me/archive/v0.4.3.zip",
-                "source": "Localize-me-0.4.3",
+                "url": "https://github.com/L-Sherry/Localize-me/archive/0.5.1.zip",
+                "source": "Localize-me-0.5.1",
                 "hash": {
-                    "sha256": "fb08dd95de63af3b057000161f74c6770012f94cc4d5718b8c73aba9055cfc0a"
+                    "sha256": "02f058f2574c233e98e5f450b20683a5133dceef59fba8decf6e04b736f89f02"
                 }
             }
         ]


### PR DESCRIPTION
Changelog at https://github.com/L-Sherry/Localize-me/releases/tag/0.5.1

Expected sha256: `02f058f2574c233e98e5f450b20683a5133dceef59fba8decf6e04b736f89f02`