### PR TITLE
Added Bob-Rank v1.0.0.

### DIFF
--- a/input-locations.json
+++ b/input-locations.json
@@ -170,6 +170,11 @@
 		"type": "modZip",
 		"urlZip": "https://github.com/Swanderrr/CCleasitstitle/raw/master/archive/titlescreenlea.zip",
 		"source": ""
+	},
+	{
+		"type": "modZip",
+		"urlZip": "https://github.com/L-Sherry/Bob-Rank/releases/download/v1.0.0/Bob-Rank-v1.0.0.zip",
+		"source": "Bob-Rank-v1.0.0"
 	}
 ]
 

--- a/mods.json
+++ b/mods.json
@@ -1,5 +1,15 @@
 {
     "mods": {
+        "Bob-Rank": {
+            "name": "Bob-Rank",
+            "description": "Adds unforgettable special effects on S-Rank",
+            "page": [],
+            "archive_link": "https://github.com/L-Sherry/Bob-Rank/releases/download/v1.0.0/Bob-Rank-v1.0.0.zip",
+            "hash": {
+                "sha256": "c403561d1d334a5fc58a2affac431aa2ebe3dbc03a1a42968a52facb6f8f7d6d"
+            },
+            "version": "1.0.0"
+        },
         "CCJoystickExt": {
             "name": "CCJoystickExt",
             "description": "Adds gamepad bindings on L3 and R3 to easily swap elements",

--- a/npDatabase.json
+++ b/npDatabase.json
@@ -1,4 +1,26 @@
 {
+    "Bob-Rank": {
+        "metadata": {
+            "name": "Bob-Rank",
+            "description": "Adds unforgettable special effects on S-Rank",
+            "plugin": "plugin.js",
+            "version": "1.0.0",
+            "assets": [
+                "assets/data/more-tile-infos.json",
+                "assets/data/map-fixes.json"
+            ]
+        },
+        "installation": [
+            {
+                "type": "modZip",
+                "url": "https://github.com/L-Sherry/Bob-Rank/releases/download/v1.0.0/Bob-Rank-v1.0.0.zip",
+                "source": "Bob-Rank-v1.0.0",
+                "hash": {
+                    "sha256": "c403561d1d334a5fc58a2affac431aa2ebe3dbc03a1a42968a52facb6f8f7d6d"
+                }
+            }
+        ]
+    },
     "CCJoystickExt": {
         "metadata": {
             "name": "CCJoystickExt",


### PR DESCRIPTION
But only the zip, not the ccmod. There are too many problems with the ccmod version to include it in the list[1].

Feel free to announce this release in #release or #modding or whatever on 1 April, which will happen in the next few minutes at Berlin time (UTC+0200)).

sha256 should be `c403561d1d334a5fc58a2affac431aa2ebe3dbc03a1a42968a52facb6f8f7d6d`


[1] The ccmod is in https://github.com/L-Sherry/Bob-Rank/releases/download/v1.0.0/Bob-Rank-v1.0.0.ccmod if anyone want to test, because i can't make it work reliably with ccloader's service worker.
(Also, i removed the dependency on main())