### PR TITLE
Bump French-CC to 0.9.0

### DIFF
--- a/input-locations.json
+++ b/input-locations.json
@@ -116,8 +116,8 @@
 	},
 	{
 		"type": "modZip",
-		"urlZip": "https://github.com/L-Sherry/French-CC/archive/v0.8.0.zip",
-		"source": "French-CC-0.8.0"
+		"urlZip": "https://github.com/L-Sherry/French-CC/archive/v0.9.0.zip",
+		"source": "French-CC-0.9.0"
 	},
 	{
 		"type": "modZip",

--- a/mods.json
+++ b/mods.json
@@ -144,11 +144,11 @@
                     "url": "https://github.com/L-Sherry/French-CC"
                 }
             ],
-            "archive_link": "https://github.com/L-Sherry/French-CC/archive/v0.8.0.zip",
+            "archive_link": "https://github.com/L-Sherry/French-CC/archive/v0.9.0.zip",
             "hash": {
-                "sha256": "9f23b816191ee786274666c8d2d39081b9ad0870280ddbc632915b9545ae3b28"
+                "sha256": "a0299c17bf1a91e07aed691f437f3b1c4bb6b05f3c7e3ad3fe8af1c1c62fab25"
             },
-            "version": "0.8.0"
+            "version": "0.9.0"
         },
         "Kit Player": {
             "name": "Kit Player",

--- a/npDatabase.json
+++ b/npDatabase.json
@@ -245,7 +245,7 @@
             "homepage": "https://github.com/L-Sherry/French-CC",
             "postload": "mod.js",
             "module": true,
-            "version": "0.8.0",
+            "version": "0.9.0",
             "ccmodDependencies": {
                 "Localize Me": ">=0.5 <1"
             }
@@ -253,10 +253,10 @@
         "installation": [
             {
                 "type": "modZip",
-                "url": "https://github.com/L-Sherry/French-CC/archive/v0.8.0.zip",
-                "source": "French-CC-0.8.0",
+                "url": "https://github.com/L-Sherry/French-CC/archive/v0.9.0.zip",
+                "source": "French-CC-0.9.0",
                 "hash": {
-                    "sha256": "9f23b816191ee786274666c8d2d39081b9ad0870280ddbc632915b9545ae3b28"
+                    "sha256": "a0299c17bf1a91e07aed691f437f3b1c4bb6b05f3c7e3ad3fe8af1c1c62fab25"
                 }
             }
         ]


### PR DESCRIPTION
Changelog: https://github.com/L-Sherry/French-CC/releases/tag/v0.9.0

SHA-256 should be `a0299c17bf1a91e07aed691f437f3b1c4bb6b05f3c7e3ad3fe8af1c1c62fab25`