### PR TITLE
Replace Travis CI with Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+name: CI
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  check_database:
+    name: Check database
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 15.x
+    - working-directory: build/
+      run: npm ci
+    - working-directory: build/
+      run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-- "stable"
-install:
-  cd build && npm ci && cd ..
-script: cd build && npm test
-sudo: false


### PR DESCRIPTION
I didn't enable caching of `node_modules` though, but compared to the run time of `npm test` time spent installing dependencies is negligible.