### PR TITLE
Remove enhanced-ui from the database

### DIFF
--- a/input-locations.json
+++ b/input-locations.json
@@ -223,11 +223,6 @@
 	},
 	{
 		"type": "modZip",
-		"urlZip": "https://github.com/CCDirectLink/crosscode-ru/releases/download/v1.0.5/crosscode-ru_v1.0.5.zip",
-		"source": "crosscode-ru"
-	},
-	{
-		"type": "modZip",
 		"urlZip": "https://github.com/dmitmel/crosscode-readable-saves/releases/download/v1.0.0/crosscode-readable-saves_v1.0.0.zip",
 		"source": "crosscode-readable-saves"
 	},

--- a/input-locations.json
+++ b/input-locations.json
@@ -223,11 +223,6 @@
 	},
 	{
 		"type": "modZip",
-		"urlZip": "https://github.com/CCDirectLink/crosscode-ru/releases/download/v1.0.5/enhanced-ui_v0.1.3.zip",
-		"source": "enhanced-ui"
-	},
-	{
-		"type": "modZip",
 		"urlZip": "https://github.com/CCDirectLink/crosscode-ru/releases/download/v1.0.5/crosscode-ru_v1.0.5.zip",
 		"source": "crosscode-ru"
 	},

--- a/mods.json
+++ b/mods.json
@@ -337,22 +337,6 @@
             },
             "version": "1.0.1"
         },
-        "crosscode-ru": {
-            "name": "crosscode-ru",
-            "description": "Russian translation for CrossCode",
-            "license": "(MIT AND CC-BY-4.0)",
-            "page": [
-                {
-                    "name": "GitHub",
-                    "url": "https://github.com/dmitmel/crosscode-ru"
-                }
-            ],
-            "archive_link": "https://github.com/CCDirectLink/crosscode-ru/releases/download/v1.0.5/crosscode-ru_v1.0.5.zip",
-            "hash": {
-                "sha256": "801447c85df76cf1e981e9f3f805c095568b20834e17476d580452472216d064"
-            },
-            "version": "1.0.5"
-        },
         "extendable-severed-heads": {
             "name": "extendable-severed-heads",
             "description": "A mod. (Description not available; contact mod author and have them add a description to their package.json file)",

--- a/mods.json
+++ b/mods.json
@@ -353,22 +353,6 @@
             },
             "version": "1.0.5"
         },
-        "enhanced-ui": {
-            "name": "Enhanced UI",
-            "description": "Various GUI enhancments and fixes",
-            "license": "MIT",
-            "page": [
-                {
-                    "name": "GitHub",
-                    "url": "https://github.com/dmitmel/crosscode-ru/tree/master/enhanced-ui"
-                }
-            ],
-            "archive_link": "https://github.com/CCDirectLink/crosscode-ru/releases/download/v1.0.5/enhanced-ui_v0.1.3.zip",
-            "hash": {
-                "sha256": "a8e5680c0b14f363c2ffeb8f69d5f449319b533abef42c10bb6fb4b611550dda"
-            },
-            "version": "0.1.3"
-        },
         "extendable-severed-heads": {
             "name": "extendable-severed-heads",
             "description": "A mod. (Description not available; contact mod author and have them add a description to their package.json file)",

--- a/npDatabase.json
+++ b/npDatabase.json
@@ -605,55 +605,6 @@
             }
         ]
     },
-    "crosscode-ru": {
-        "metadata": {
-            "private": true,
-            "name": "crosscode-ru",
-            "version": "1.0.5",
-            "license": "(MIT AND CC-BY-4.0)",
-            "description": "Russian translation for CrossCode",
-            "homepage": "https://github.com/dmitmel/crosscode-ru",
-            "engines": {
-                "node": ">=11.0.0"
-            },
-            "module": true,
-            "plugin": "dist/plugin.js",
-            "postload": "dist/postload.js",
-            "prestart": "dist/prestart.js",
-            "ccmodDependencies": {
-                "crosscode": ">=1.2.0",
-                "Localize Me": "^0.5.2",
-                "enhanced-ui": "^0.1.0",
-                "CCLoader display version": "^1.0.0"
-            },
-            "devDependencies": {
-                "@typescript-eslint/eslint-plugin": "^2.24.0",
-                "@typescript-eslint/parser": "^2.24.0",
-                "eslint": "^6.8.0",
-                "eslint-config-dmitmel": "dmitmel/eslint-config-dmitmel",
-                "eslint-plugin-node": "^11.0.0",
-                "eslint-plugin-prettier": "^3.1.3",
-                "prettier": "^2.0.5",
-                "typescript": "~3.8.3",
-                "ultimate-crosscode-typedefs": "dmitmel/ultimate-crosscode-typedefs"
-            },
-            "scripts": {
-                "build": "tsc --build",
-                "watch": "tsc --build --watch",
-                "lint": "eslint . --ext .js,.ts --ignore-path .gitignore"
-            }
-        },
-        "installation": [
-            {
-                "type": "modZip",
-                "url": "https://github.com/CCDirectLink/crosscode-ru/releases/download/v1.0.5/crosscode-ru_v1.0.5.zip",
-                "source": "crosscode-ru",
-                "hash": {
-                    "sha256": "801447c85df76cf1e981e9f3f805c095568b20834e17476d580452472216d064"
-                }
-            }
-        ]
-    },
     "extendable-severed-heads": {
         "metadata": {
             "name": "extendable-severed-heads",

--- a/npDatabase.json
+++ b/npDatabase.json
@@ -654,40 +654,6 @@
             }
         ]
     },
-    "enhanced-ui": {
-        "metadata": {
-            "private": true,
-            "name": "enhanced-ui",
-            "ccmodHumanName": "Enhanced UI",
-            "version": "0.1.3",
-            "license": "MIT",
-            "description": "Various GUI enhancments and fixes",
-            "homepage": "https://github.com/dmitmel/crosscode-ru/tree/master/enhanced-ui",
-            "engines": {
-                "node": ">=11.0.0"
-            },
-            "module": true,
-            "postload": "dist/postload.js",
-            "ccmodDependencies": {
-                "crosscode": ">=1.2.0"
-            },
-            "devDependencies": {},
-            "scripts": {
-                "build": "../node_modules/.bin/tsc --build",
-                "watch": "../node_modules/.bin/tsc --build --watch"
-            }
-        },
-        "installation": [
-            {
-                "type": "modZip",
-                "url": "https://github.com/CCDirectLink/crosscode-ru/releases/download/v1.0.5/enhanced-ui_v0.1.3.zip",
-                "source": "enhanced-ui",
-                "hash": {
-                    "sha256": "a8e5680c0b14f363c2ffeb8f69d5f449319b533abef42c10bb6fb4b611550dda"
-                }
-            }
-        ]
-    },
     "extendable-severed-heads": {
         "metadata": {
             "name": "extendable-severed-heads",


### PR DESCRIPTION
People seem to be mistaking it for a general QoL mod and thinking that installing it will change something, while the mod itself is strictly speaking a component of cc-ru and doesn't introduce any visible changes, at least not on the `en_US` locale. cc-ru itself is still left in the DB for marketing purposes.