### PR TITLE
Bump French-CC to 0.11.0

### DIFF
--- a/input-locations.json
+++ b/input-locations.json
@@ -138,8 +138,8 @@
 	},
 	{
 		"type": "modZip",
-		"urlZip": "https://github.com/L-Sherry/French-CC/archive/v0.10.0.zip",
-		"source": "French-CC-0.10.0"
+		"urlZip": "https://github.com/L-Sherry/French-CC/archive/v0.11.0.zip",
+		"source": "French-CC-0.11.0"
 	},
 	{
 		"type": "modZip",

--- a/mods.json
+++ b/mods.json
@@ -164,11 +164,11 @@
                     "url": "https://github.com/L-Sherry/French-CC"
                 }
             ],
-            "archive_link": "https://github.com/L-Sherry/French-CC/archive/v0.10.0.zip",
+            "archive_link": "https://github.com/L-Sherry/French-CC/archive/v0.11.0.zip",
             "hash": {
-                "sha256": "ea0c2f3f9cd4f3ad7fa4288f44223591056d72015003a87e2e691f5fd9559b61"
+                "sha256": "e55d4983a65b22715aa98f0ec549e160d0f46fd6ecb4ea34d0f07898194c3619"
             },
-            "version": "0.10.0"
+            "version": "0.11.0"
         },
         "Kit Player": {
             "name": "Kit Player",

--- a/npDatabase.json
+++ b/npDatabase.json
@@ -299,7 +299,7 @@
             "homepage": "https://github.com/L-Sherry/French-CC",
             "postload": "mod.js",
             "module": true,
-            "version": "0.10.0",
+            "version": "0.11.0",
             "ccmodDependencies": {
                 "Localize Me": ">=0.5 <1"
             }
@@ -307,10 +307,10 @@
         "installation": [
             {
                 "type": "modZip",
-                "url": "https://github.com/L-Sherry/French-CC/archive/v0.10.0.zip",
-                "source": "French-CC-0.10.0",
+                "url": "https://github.com/L-Sherry/French-CC/archive/v0.11.0.zip",
+                "source": "French-CC-0.11.0",
                 "hash": {
-                    "sha256": "ea0c2f3f9cd4f3ad7fa4288f44223591056d72015003a87e2e691f5fd9559b61"
+                    "sha256": "e55d4983a65b22715aa98f0ec549e160d0f46fd6ecb4ea34d0f07898194c3619"
                 }
             }
         ]


### PR DESCRIPTION
This is mostly to fix an incompatibility with the latest CCLoader v2.