### PR TITLE
Bump CrossCodeCheats to 1.3.7

### DIFF
--- a/input-locations.json
+++ b/input-locations.json
@@ -33,8 +33,8 @@
 	},
 	{
 		"type": "modZip",
-		"urlZip": "https://github.com/ZeikJT/CrossCodeCheats/archive/1.3.5.zip",
-		"source": "CrossCodeCheats-1.3.5"
+		"urlZip": "https://github.com/ZeikJT/CrossCodeCheats/archive/1.3.7.zip",
+		"source": "CrossCodeCheats-1.3.7"
 	},
 	{
 		"type": "modZip",

--- a/mods.json
+++ b/mods.json
@@ -99,11 +99,11 @@
                     "url": "https://github.com/ZeikJT/CrossCodeCheats"
                 }
             ],
-            "archive_link": "https://github.com/ZeikJT/CrossCodeCheats/archive/1.3.5.zip",
+            "archive_link": "https://github.com/ZeikJT/CrossCodeCheats/archive/1.3.7.zip",
             "hash": {
-                "sha256": "70ca5b50c04478e85cc5fe84860a3f702d1a9498e4060b58f30363ad68aa4005"
+                "sha256": "1d69e191cafa68cc6c5cd76b98a78580f9b5fa7c1a44c8555f21c67154c4c846"
             },
-            "version": "1.3.5"
+            "version": "1.3.7"
         },
         "CrossCode C Edition": {
             "name": "CrossCode C Edition",

--- a/npDatabase.json
+++ b/npDatabase.json
@@ -181,21 +181,21 @@
         "metadata": {
             "name": "Cheats",
             "postload": "cheats.js",
-            "version": "1.3.5",
+            "version": "1.3.7",
             "homepage": "https://github.com/ZeikJT/CrossCodeCheats",
             "description": "This mod adds cheats to CrossCode.",
             "ccmodDependencies": {
                 "ccloader": "^2.11.0",
-                "crosscode": "1.2 - 1.3"
+                "crosscode": ">=1.2"
             }
         },
         "installation": [
             {
                 "type": "modZip",
-                "url": "https://github.com/ZeikJT/CrossCodeCheats/archive/1.3.5.zip",
-                "source": "CrossCodeCheats-1.3.5",
+                "url": "https://github.com/ZeikJT/CrossCodeCheats/archive/1.3.7.zip",
+                "source": "CrossCodeCheats-1.3.7",
                 "hash": {
-                    "sha256": "70ca5b50c04478e85cc5fe84860a3f702d1a9498e4060b58f30363ad68aa4005"
+                    "sha256": "1d69e191cafa68cc6c5cd76b98a78580f9b5fa7c1a44c8555f21c67154c4c846"
                 }
             }
         ]


### PR DESCRIPTION
Updated package.json to support newer cross code versions.