### PR TITLE
Update CCExtraGamepadOptions to 1.0.2

### DIFF
--- a/input-locations.json
+++ b/input-locations.json
@@ -232,8 +232,8 @@
 	},
 	{
 		"type": "modZip",
-		"urlZip": "https://github.com/ubergeek77/CCExtraGamepadOptions/archive/1.0.0.zip",
-		"source": "CCExtraGamepadOptions-1.0.0"
+		"urlZip": "https://github.com/ubergeek77/CCExtraGamepadOptions/archive/1.0.2.zip",
+		"source": "CCExtraGamepadOptions-1.0.2"
 	},
 	{
 		"type": "ccmod",

--- a/mods.json
+++ b/mods.json
@@ -177,13 +177,13 @@
         },
         "Extra Gamepad Options": {
             "name": "Extra Gamepad Options",
-            "description": "Adds a Nintendo Switch icon theme (with 3 color schemes), and allows for the swapping of A/B, X/Y, L/R, and LT/RT.",
+            "description": "Allows buttons/triggers to be swapped, and adds extra icon themes.",
             "page": [],
-            "archive_link": "https://github.com/ubergeek77/CCExtraGamepadOptions/archive/1.0.0.zip",
+            "archive_link": "https://github.com/ubergeek77/CCExtraGamepadOptions/archive/1.0.2.zip",
             "hash": {
-                "sha256": "b8814cebf4f3e5b89accf3d32e0d9915bb109a4a5a1e3aca4147ade088f08c69"
+                "sha256": "5df1571d3d1e991f2fbabab73d56d99bd185a659c66d44603b9cd3d504b7a8ac"
             },
-            "version": "1.0.0"
+            "version": "1.0.2"
         },
         "French": {
             "name": "French",

--- a/npDatabase.json
+++ b/npDatabase.json
@@ -331,8 +331,8 @@
     "Extra Gamepad Options": {
         "metadata": {
             "name": "Extra Gamepad Options",
-            "version": "1.0.0",
-            "description": "Adds a Nintendo Switch icon theme (with 3 color schemes), and allows for the swapping of A/B, X/Y, L/R, and LT/RT.",
+            "version": "1.0.2",
+            "description": "Allows buttons/triggers to be swapped, and adds extra icon themes.",
             "module": false,
             "prestart": "prestart.js",
             "ccmodDependencies": {}
@@ -340,10 +340,10 @@
         "installation": [
             {
                 "type": "modZip",
-                "url": "https://github.com/ubergeek77/CCExtraGamepadOptions/archive/1.0.0.zip",
-                "source": "CCExtraGamepadOptions-1.0.0",
+                "url": "https://github.com/ubergeek77/CCExtraGamepadOptions/archive/1.0.2.zip",
+                "source": "CCExtraGamepadOptions-1.0.2",
                 "hash": {
-                    "sha256": "b8814cebf4f3e5b89accf3d32e0d9915bb109a4a5a1e3aca4147ade088f08c69"
+                    "sha256": "5df1571d3d1e991f2fbabab73d56d99bd185a659c66d44603b9cd3d504b7a8ac"
                 }
             }
         ]


### PR DESCRIPTION
This release adds a theme for the newly released 8BitDo SN30 Pro 2 controller. Some minor pixel adjustments to the rest of the sprite sheet were also made, and the package description was reduced to better fit the in-game mod description.