### PR TITLE
Update Cheats mod to V 1.4.0

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -114,11 +114,11 @@
                     "url": "https://github.com/ZeikJT/CrossCodeCheats"
                 }
             ],
-            "archive_link": "https://github.com/ZeikJT/CrossCodeCheats/archive/1.3.7.zip",
+            "archive_link": "https://github.com/ZeikJT/CrossCodeCheats/archive/1.4.0.zip",
             "hash": {
-                "sha256": "1d69e191cafa68cc6c5cd76b98a78580f9b5fa7c1a44c8555f21c67154c4c846"
+                "sha256": "ff903d75f2098fbe3061ea8cc309f55a54c15050ddb4395606439ac8a8268faf"
             },
-            "version": "1.3.7"
+            "version": "1.4.0"
         },
         "CrossCode C Edition": {
             "name": "CrossCode C Edition",


### PR DESCRIPTION
New release: https://github.com/ZeikJT/CrossCodeCheats/releases/tag/1.4.0