### PR TITLE
Remove DLC Arena Music Fix

### DIFF
--- a/input-locations.json
+++ b/input-locations.json
@@ -245,15 +245,6 @@
 		"source": "CCInventorySearch-1.0.0/src"
 	},
 	{
-		"type": "modZip",
-		"urlZip": "https://github.com/EL20202/cc-dlc-arena-music-fix/archive/refs/tags/v1.0.0.zip",
-		"source": "cc-dlc-arena-music-fix-1.0.0"
-	},
-	{
-		"type": "ccmod",
-		"url": "https://github.com/EL20202/cc-dlc-arena-music-fix/releases/download/v1.0.0/cc-dlc-arena-music-fix.v1.0.0.ccmod"
-	},
-	{
 		"type": "ccmod",
 		"url": "https://github.com/EL20202/cc-capped-stats/releases/download/v1.0.0/cc-capped-stats.ccmod"
 	},

--- a/mods.json
+++ b/mods.json
@@ -130,21 +130,6 @@
             },
             "version": "1.0.0"
         },
-        "DLC Arena Music Fix": {
-            "name": "DLC Arena Music Fix",
-            "description": "Fixes the music that plays in some DLC Arena rounds.",
-            "page": [
-                {
-                    "name": "GitHub",
-                    "url": "https://github.com/EL20202/cc-uncapped-stats"
-                }
-            ],
-            "archive_link": "https://github.com/EL20202/cc-dlc-arena-music-fix/releases/download/v1.0.0/cc-dlc-arena-music-fix.v1.0.0.ccmod",
-            "hash": {
-                "sha256": "dc278e20dd475a5da04143e3447486ff8ee2253298890a58d59716a48b248e95"
-            },
-            "version": "1.0.0"
-        },
         "Discord": {
             "name": "Rich Presence for Discord",
             "description": "Show off your CrossCode skills in Discord",

--- a/npDatabase.json
+++ b/npDatabase.json
@@ -254,34 +254,6 @@
             }
         ]
     },
-    "DLC Arena Music Fix": {
-        "metadata": {
-            "name": "DLC Arena Music Fix",
-            "version": "1.0.0",
-            "description": "Fixes the music that plays in some DLC Arena rounds.",
-            "homepage": "https://github.com/EL20202/cc-uncapped-stats",
-            "ccmodDependencies": {
-                "ccloader": "^2.20.0"
-            }
-        },
-        "installation": [
-            {
-                "type": "modZip",
-                "url": "https://github.com/EL20202/cc-dlc-arena-music-fix/archive/refs/tags/v1.0.0.zip",
-                "source": "cc-dlc-arena-music-fix-1.0.0",
-                "hash": {
-                    "sha256": "1a163abc0d7047afeb71801875510d618142200b30aae549b6d007f9d457acdc"
-                }
-            },
-            {
-                "type": "ccmod",
-                "url": "https://github.com/EL20202/cc-dlc-arena-music-fix/releases/download/v1.0.0/cc-dlc-arena-music-fix.v1.0.0.ccmod",
-                "hash": {
-                    "sha256": "dc278e20dd475a5da04143e3447486ff8ee2253298890a58d59716a48b248e95"
-                }
-            }
-        ]
-    },
     "Discord": {
         "metadata": {
             "name": "Discord",


### PR DESCRIPTION
Requested by the author:
> hey do you guys mind removing a mod
> dlc arena music fix is no longer needed
> as the bug it fixes has been fixed in vanilla
https://discord.com/channels/143364538958348288/276459212807340034/961332367388192828