### PR TITLE
Enforce mod tags to be valid

### DIFF
--- a/build/src/types.ts
+++ b/build/src/types.ts
@@ -87,7 +87,7 @@ export type PkgMetadata = {
 
 type FilePath = string
 
-type LocalizedString = Record<Locale, string> | string
+export type LocalizedString = Record<Locale, string> | string
 type Locale = string
 
 type Person = /* PersonDetails | */ string
@@ -98,33 +98,41 @@ type Person = /* PersonDetails | */ string
 /**     comment?: LocalizedString */
 /** } */
 
+
 /**
  * Mod tags that are in the ccmod.json standard
  **/
-export type ValidTags =
-    | 'QoL'
-    | 'player character'
-    | 'party member'
-    | 'combat arts'
-    | 'pvp duel'
-    | 'arena'
-    | 'dungeon'
-    | 'quests'
-    | 'maps'
-    | 'boss'
-    | 'puzzle'
-    | 'ng+'
-    | 'cosmetic'
-    | 'fun'
-    | 'cheats'
-    | 'speedrun'
-    | 'widget'
-    | 'language'
-    | 'accessibility'
-    | 'dev'
-    | 'library'
-    | 'base'
-    | 'externaltool'
+export const ValidTags = [
+    'QoL',
+    'player character',
+    'party member',
+    'combat arts',
+    'pvp duel',
+    'arena',
+    'dungeon',
+    'quests',
+    'maps',
+    'boss',
+    'puzzle',
+    'ng+',
+    'cosmetic',
+    'fun',
+    'cheats',
+    'speedrun',
+    'widget',
+    'language',
+    'accessibility',
+    'dev',
+    'library',
+    'base',
+    'externaltool'
+] as const
+
+/**
+ * Mod tags that are in the ccmod.json standard
+ **/
+export type ValidTags = typeof ValidTags[number]
+
 /**
  * All mods in the database must have these fields
  **/

--- a/build/src/types.ts
+++ b/build/src/types.ts
@@ -116,6 +116,7 @@ export const ValidTags = [
     'puzzle',
     'ng+',
     'cosmetic',
+    'music',
     'fun',
     'cheats',
     'speedrun',

--- a/build/tests/npDatabase.ts
+++ b/build/tests/npDatabase.ts
@@ -12,6 +12,7 @@ import {
     Package,
     PackageDB,
     PkgCCMod,
+    ValidTags,
 } from '../src/types'
 import { getRepoBranches, gitReadFunc } from '../src/git'
 
@@ -188,6 +189,15 @@ function testMetadataCCMod(ccmod: PkgCCMod) {
             ccmod.tags !== undefined && Array.isArray(ccmod.tags),
             'ccmod.tags (type: array) is missing or has wrong type'
         ).to.be.true
+
+        const tags = (ccmod.tags ?? []).sort()
+        for (let i = 0; i < tags.length; i++) {
+            const tag = tags[i]
+            expect(ValidTags.includes(tag), `ccmod.tags (type: array) has an invalid tag: "${tag}"`)
+                .to.be.true
+            expect(tags[i - 1] != tag, `ccmod.tags (type: array) has a duplicate tag: "${tag}"`).to
+                .be.true
+        }
 
         expect(
             ccmod.authors !== undefined && Array.isArray(ccmod.tags),

--- a/docs/CCMOD-STANDARD.md
+++ b/docs/CCMOD-STANDARD.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD013 MD034 -->
 
-# `ccmod.json` format standard v1.0.0
+# `ccmod.json` format standard v1.0.1
 
 ## Each option explained
 
@@ -36,6 +36,7 @@
 - `puzzle` - adds new puzzles or something puzzle related
 - `ng+` - adds additional ng+ options
 - `cosmetic` - adds any kind of cosmetic things like skins, pets or menu skins
+- `music` - adds or replaces music and/or sounds
 - `fun` - fun things not necessarily useful
 - `cheats` - do things you're not supposed to do like spawn items or infinite gold
 - `speedrun` - helps speedrunners with speedruns or practice


### PR DESCRIPTION
- **Fix types.ts errors and make ValidTags an array**
- **Enforce mod tags to be valid**

The CI is supposed to fail, I will work on updating the mods that have invalid tags in them.